### PR TITLE
Hardcode output paths

### DIFF
--- a/tinyhackathon/submission.py
+++ b/tinyhackathon/submission.py
@@ -263,20 +263,19 @@ def whoami():
 
 @app.command()
 def download_eval(
-    output_file: Annotated[Path, typer.Option(help="Evaluation prompts file")] = "evaluation_prompts.csv",
-    path_in_repo: Annotated[str, typer.Option(help="Path to file within the repository")] = "evaluation_prompts.csv",
     repo_id: Annotated[str, typer.Option(help="Hugging Face repository ID")] = "cluster-of-stars/tiny_stories_evaluation_prompts",
 ):  # fmt: skip
     "Download evaluation prompts for Tiny Stories hackathon"
     api = HfApi()
+    filename = "evaluation_prompts.csv"
     try:
         api.hf_hub_download(
             repo_id=repo_id,
-            filename=path_in_repo,
-            local_dir=os.path.dirname(output_file) or ".",
+            filename=filename,
+            local_dir=".",
             repo_type="dataset",
         )
-        console.print(f"[green]Successfully downloaded and saved to {output_file}[/green]")
+        console.print(f"[green]Successfully downloaded and saved to {Path(filename).absolute()}[/green]")
     except Exception as e:
         console.print(f"[red]Error: Failed to download: {str(e)}[/red]")
 


### PR DESCRIPTION
The parameters to `download_eval` confused me a bit and don't appear to be working as intended.

If you run `uv run submission.py download-eval --output-file my_file_location.csv`, the `--output-file my_file_location.csv` bit doesn't do anything. `os.path.dirname("my_file_location.csv")` returns `"."`. The file will appear at "evaluation_prompts.csv" because of `path_in_repo`.

I suggest that this functionality is unnecessary, and we can just put the file at "evaluation_prompts.csv". Folks can move it from there if they want to. However, I'm open to reworking it instead.