### PR TITLE
Allow positional submission path

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -46,6 +46,8 @@ python submission.py submit PATH_TO_FILE [--submission-name NAME] --submit
 uv run submission.py submit PATH_TO_FILE [--submission-name NAME] --submit
 ```
 
+where `submission-name` is an optional human-readable name for the submission.
+
 By default, the submission script will submit to the test dataset which will not be scored. For a realsubmission, use the `--submit` flag.
 
 > Note: You are limited to one submission per day.

--- a/tinyhackathon/submission.py
+++ b/tinyhackathon/submission.py
@@ -224,7 +224,7 @@ def upload_submission(
 
 @app.command()
 def submit(
-    submission_path: Annotated[Path, typer.Option(help="Path to the submission file", show_default=False)],
+    submission_path: Annotated[Path, typer.Argument(help="Path to the submission file")],
     submission_name: Annotated[Optional[str], typer.Option(help="Optional user friendly name of the submission ")] = None,
     weight_class: Annotated[Optional[WeightClass], typer.Option(help="Model weight class size (small: up to 30M, medium: up to 60M, or large: up to 120M). If provided this will update the current model weight class.")] = None,
     submit: Annotated[bool, typer.Option("--submit/--test",help="Upload submission (--submit) or test submission (--test). Default's to test submission.")] = False,


### PR DESCRIPTION
The command `uv run submission.py submit PATH_TO_FILE` given in the ReadMe doesn't currently work. `submission_path` can only be passed as a keyword argument because it is configured as a `typer.Option` rather than a `typer.Argument`. This PR changes it to a `typer.Argument`.

It also adds a line to the ReadMe to clarify the purpose of `submission_name`.