### PR TITLE
fix: use submission name in uploaded file name

### DIFF
--- a/tinyhackathon/submission.py
+++ b/tinyhackathon/submission.py
@@ -178,7 +178,7 @@ def upload_submission(
         df.to_csv(save_path, index=False)
 
         # Upload to HF
-        remote_path = f"submissions/{username}/{timestamp}.csv"
+        remote_path = f"submissions/{username}/{file_name}"
         api.upload_file(path_or_fileobj=str(save_path), path_in_repo=remote_path, repo_id=hf_repo, repo_type="dataset")
 
         # Handle metadata.json - get existing if we don't have it yet


### PR DESCRIPTION
All submissions currently only use the timestamp, and throw away any submission name given. This change ensures that if a sbumission_name is given, it will be used as part of the uploaded file name.